### PR TITLE
Add check for optional Excel file creation

### DIFF
--- a/main.go
+++ b/main.go
@@ -141,11 +141,13 @@ func main() {
 	}
 	log.Printf("Successfully created CSV file: %q", config.CSVFile)
 
-	// Generate Excel workbook for review
-	// TODO: Implement better error handling
-	if err := fileChecksumIndex.WriteFileMatchesWorkbook(config.ExcelFile, duplicateFiles); err != nil {
-		log.Fatal(err)
+	// Generate Excel workbook for review IF user requested it
+	if config.ExcelFile != "" {
+		// TODO: Implement better error handling
+		if err := fileChecksumIndex.WriteFileMatchesWorkbook(config.ExcelFile, duplicateFiles); err != nil {
+			log.Fatal(err)
+		}
+		log.Printf("Successfully created workbook file: %q", config.ExcelFile)
 	}
-	log.Printf("Successfully created workbook file: %q", config.ExcelFile)
 
 }


### PR DESCRIPTION
Without this check, an attempt is made regardless of whether the user specified a filename for the optional flag; this attempt fails when the application is unable to open a file without a valid filename.

fixes #34