### PR TITLE
Update minimum Go version requirement to 1.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ official release is also provided for further review.
 
 ## Requirements
 
-- Go 1.12+ (for building)
+- Go 1.13+ (for building)
 - GCC
   - if building with custom options (as the provided `Makefile` does)
 - `make`


### PR DESCRIPTION
This coincides with dropping Go 1.12 in our GitHub Actions Workflow and plans to begin using `errors.Is()` and `errors.As()` (new in Go 1.13).

refs #49