### PR TITLE
Fix Makefile builds to properly set version string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ The following types of changes will be recorded in this file:
 
 - placeholder
 
+## [v0.4.1] - 2020-03-02
+
+### Fixed
+
+- (GH-55) `Makefile` builds failed to set version information
+
 ## [v0.4.0] - 2020-02-27
 
 ### Added
@@ -113,7 +119,8 @@ Worth noting (in no particular order):
 - Makefile for general use cases
 - No external, non-standard library packages
 
-[Unreleased]: https://github.com/atc0005/bridge/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/atc0005/bridge/compare/v0.4.1...HEAD
+[v0.4.1]: https://github.com/atc0005/bridge/releases/tag/v0.4.1
 [v0.4.0]: https://github.com/atc0005/bridge/releases/tag/v0.4.0
 [v0.3.0]: https://github.com/atc0005/bridge/releases/tag/v0.3.0
 [v0.2.0]: https://github.com/atc0005/bridge/releases/tag/v0.2.0

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@
 
 APPNAME					:= bridge
 
+# What package holds the "version" variable used in branding/version output?
+VERSION_VAR_PKG			= github.com/atc0005/bridge/config
+
 OUTPUTDIR 				:= release_assets
 
 # https://gist.github.com/TheHippo/7e4d9ec4b7ed4c0d7a39839e6800cc16
@@ -26,7 +29,7 @@ VERSION 				:= $(shell git describe --always --long --dirty)
 
 # The default `go build` process embeds debugging information. Building
 # without that debugging information reduces the binary size by around 28%.
-BUILDCMD				:=	go build -a -ldflags="-s -w -X main.version=${VERSION}"
+BUILDCMD				:=	go build -a -ldflags="-s -w -X $(VERSION_VAR_PKG).version=$(VERSION)"
 GOCLEANCMD				:=	go clean
 GITCLEANCMD				:= 	git clean -xfd
 CHECKSUMCMD				:=	sha256sum -b

--- a/README.md
+++ b/README.md
@@ -330,4 +330,7 @@ of this document for links to additional information.
 
 - <https://medium.com/@sebassegros/golang-dealing-with-maligned-structs-9b77bacf4b97>
 
+- <https://goenning.net/2017/01/25/adding-custom-data-go-binaries-compile-time/>
+  - covers updating variables at build time, particularly sub-packages (GH-55)
+
 - <https://github.com/360EntSecGroup-Skylar/excelize>

--- a/config/config.go
+++ b/config/config.go
@@ -41,9 +41,10 @@ const PruneSubcommand string = "prune"
 // of the subcommand of the same name.
 const ReportSubcommand string = "report"
 
-// Updated via Makefile builds. Setting placeholder value here so that
-// something resembling a version string will be provided for non-Makefile
-// builds.
+// version is updated via Makefile builds by referencing the fully-qualified
+// path to this variable, including the package. We set a placeholder value so
+// that something resembling a version string will be provided for
+// non-Makefile builds.
 var version string = "x.y.z"
 
 const myAppName string = "bridge"


### PR DESCRIPTION
- Update Makefile to properly set version string by
  specifying the `config.version` variable by
  fully-qualified package path

- Update CHANGELOG to reference the fix

- Update README to reference the article which
  provided the fix

- Update `version` doc comment to better explain
  the requirement for setting the variable at
  build time

fixes #55