### PR TITLE
golangci-lint: export settings, add golint linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,33 @@
+# Copyright 2020 Adam Chalkley
+#
+# https://github.com/atc0005/elbow
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+linters:
+  enable:
+    - dogsled
+    - goimports
+    - gosec
+    - stylecheck
+    - goconst
+    - depguard
+    - prealloc
+    - misspell
+    - maligned
+    - dupl
+    - unconvert
+    - gofmt
+    - golint
+    - gocritic
+    - scopelint

--- a/testing/install_linting_tools.sh
+++ b/testing/install_linting_tools.sh
@@ -20,7 +20,6 @@ export GO111MODULE="off"
 # https://github.com/golangci/golangci-lint/releases/latest
 GOLANGCI_LINT_VERSION="v1.25.1"
 
-go get -u golang.org/x/lint/golint
 go get -u honnef.co/go/tools/cmd/staticcheck
 
 echo Installing golangci-lint ${GOLANGCI_LINT_VERSION} per official binary installation docs ...

--- a/testing/run_linting_checks.sh
+++ b/testing/run_linting_checks.sh
@@ -24,44 +24,12 @@ failed_app=""
 ###########################################################
 
 
-# https://stackoverflow.com/a/42510278/903870
-diff -u <(echo -n) <(gofmt -l -e -d .)
-
-status=$?
-if [[ $status -ne 0 ]]; then
-    final_exit_code=$status
-    failed_app="gofmt"
-    echo "Non-zero exit code from $failed_app: $status"
-fi
-
 go vet ./...
 
 status=$?
 if [[ $status -ne 0 ]]; then
     final_exit_code=$status
     failed_app="go vet"
-    echo "Non-zero exit code from $failed_app: $status"
-fi
-
-if ! which golint > /dev/null; then
-cat <<\EOF
-Error: Unable to locate "golint"
-
-Install golint with the following command:
-
-make lintinstall
-
-EOF
-    exit 1
-else
-    golint -set_exit_status ./...
-fi
-
-# TODO: This might not be needed based on use of "-set_exit_status"
-status=$?
-if [[ $status -ne 0 ]]; then
-    final_exit_code=$status
-    failed_app="staticcheck"
     echo "Non-zero exit code from $failed_app: $status"
 fi
 
@@ -76,19 +44,7 @@ make lintinstall
 EOF
     exit 1
 else
-    golangci-lint run \
-        -E goimports \
-        -E gosec \
-        -E stylecheck \
-        -E goconst \
-        -E depguard \
-        -E prealloc \
-        -E misspell \
-        -E maligned \
-        -E dupl \
-        -E unconvert \
-        -E golint \
-        -E gocritic
+    golangci-lint run
 fi
 
 status=$?


### PR DESCRIPTION
## Changes

- Skip installation of gofmt, golint linting tools

- Disable gofmt linter in called shell script

- Disable golint linter in called shell script

- Remove explicit golangci-lint linter flags

- Export list of chosen golangci-lint linters to external config file

- Add golangci-lint linters
  - `scopelint`
  - `gofmt`
  - `dogsled`

## References

- fixes #63
- fixes #66 
- fixes #59