### PR TITLE
Fix GoDoc line-wrapping formatting

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -34,8 +34,7 @@ FEATURES
 
 • generate (rough) console equivalent of CSV file for quick review
 
-• (optionally) remove user-flagged duplicate files using a previously
-  generated CSV report
+• (optionally) remove user-flagged duplicate files using a previously generated CSV report
 
 USAGE
 


### PR DESCRIPTION
GoDoc doesn't treat forced line wrapping like Markdown. Adding an explicit break causes GoDoc to think the following text is code and place it within a PRE block.

Fix this unintentional formatting by keeping the long line of text as-is.

fixes #57