### PR TITLE
Revert unintentional license change

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,17 +2,8 @@
 #
 # https://github.com/atc0005/bridge
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
 
 linters:
   enable:


### PR DESCRIPTION
When adding the golangci-lint config file in #59 I copied/pasted from another project of mine which
uses a different license.

Revert license header back to the intended license for this project.