### PR TITLE
go.mod | Update Go version from 1.13 to 1.14

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/atc0005/bridge
 
-go 1.13
+go 1.14
 
 require github.com/360EntSecGroup-Skylar/excelize/v2 v2.3.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,5 @@
 # github.com/360EntSecGroup-Skylar/excelize/v2 v2.3.0
+## explicit
 github.com/360EntSecGroup-Skylar/excelize/v2
 # github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 github.com/mohae/deepcopy


### PR DESCRIPTION
- Update "oldstable" Go version
- go mod tidy && go mod vendor