### PR TITLE
Fix various gocritic linting errors

### DIFF
--- a/checksums/checksums.go
+++ b/checksums/checksums.go
@@ -23,7 +23,7 @@ import (
 // Goal: Set SHA256Checksum as the return type for GenerateCheckSum(), but
 // make sure that the length is locked in at the specific character length
 // for our chosen file hash.
-//type SHA256Checksum [64]string
+// type SHA256Checksum [64]string
 type SHA256Checksum string
 
 func (cs SHA256Checksum) String() string {
@@ -62,7 +62,7 @@ func GenerateCheckSum(file string) (SHA256Checksum, error) {
 
 	f, err := os.Open(filepath.Clean(file))
 	if err != nil {
-		//log.Fatal(err)
+		// log.Fatal(err)
 		return checksum, err
 	}
 
@@ -79,7 +79,7 @@ func GenerateCheckSum(file string) (SHA256Checksum, error) {
 
 	h := sha256.New()
 	if _, err := io.Copy(h, f); err != nil {
-		//log.Fatal(err)
+		// log.Fatal(err)
 		return checksum, err
 	}
 

--- a/cmd/bridge/prune.go
+++ b/cmd/bridge/prune.go
@@ -21,7 +21,7 @@ import (
 )
 
 // pruneSubcommand is a wrapper around the "prune" subcommand logic
-func pruneSubcommand(appConfig *config.Config) {
+func pruneSubcommand(appConfig *config.Config) error {
 
 	// DEBUG
 	fmt.Printf("subcommand '%s' called\n", config.PruneSubcommand)
@@ -65,7 +65,7 @@ func pruneSubcommand(appConfig *config.Config) {
 			break
 		}
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		// If we are currently evaluating the very first line of the CSV file
@@ -87,7 +87,8 @@ func pruneSubcommand(appConfig *config.Config) {
 				log.Printf("IgnoringErrors set, ignoring input row %d.\n", rowCounter)
 				continue
 			}
-			log.Fatal("IgnoringErrors NOT set. Exiting.")
+			log.Println("IgnoringErrors NOT set. Exiting.")
+			return err
 		}
 
 		// validate input row before we consider it OK
@@ -97,7 +98,8 @@ func pruneSubcommand(appConfig *config.Config) {
 				log.Printf("IgnoringErrors set, ignoring input row %d.\n", rowCounter)
 				continue
 			}
-			log.Fatal("IgnoringErrors NOT set. Exiting.")
+			log.Println("IgnoringErrors NOT set. Exiting.")
+			return err
 		}
 
 		// update size details if found missing in CSV row
@@ -107,7 +109,8 @@ func pruneSubcommand(appConfig *config.Config) {
 				log.Printf("IgnoringErrors set, ignoring input row %d.\n", rowCounter)
 				continue
 			}
-			log.Fatal("IgnoringErrors NOT set. Exiting.")
+			log.Println("IgnoringErrors NOT set. Exiting.")
+			return err
 		}
 
 		// Start off with collecting all entries in the CSV file that contain
@@ -138,7 +141,7 @@ func pruneSubcommand(appConfig *config.Config) {
 		fmt.Printf("0 entries out of %d marked for removal in the %q input CSV file.\n",
 			len(dfsEntries), appConfig.InputCSVFile)
 		fmt.Println("Nothing to do, exiting.")
-		return
+		return nil
 	}
 
 	// INFO? DEBUG?
@@ -174,7 +177,7 @@ func pruneSubcommand(appConfig *config.Config) {
 				// permissions, creating it as this application could lead to a
 				// lot of problems that we cannot reliably anticipate and prevent
 
-				log.Fatalf(
+				return fmt.Errorf(
 					"backup directory %q specified, but does not exist",
 					appConfig.BackupDirectory,
 				)
@@ -199,7 +202,7 @@ func pruneSubcommand(appConfig *config.Config) {
 					// FIXME: Implement check for appconfig.IgnoreErrors
 					// extend error message (potentially) to note that the error
 					// was encountered when creating a backup
-					log.Fatal(err)
+					return err
 				}
 
 			}
@@ -227,7 +230,8 @@ func pruneSubcommand(appConfig *config.Config) {
 					filesRemovedFail++
 					continue
 				}
-				log.Fatal("IgnoringErrors NOT set. Exiting.")
+				log.Println("IgnoringErrors NOT set. Exiting.")
+				return err
 			}
 
 			// note that we have successfully removed a file
@@ -244,4 +248,6 @@ func pruneSubcommand(appConfig *config.Config) {
 	if appConfig.DryRun {
 		fmt.Println("Dry-run enabled, no files removed")
 	}
+
+	return nil
 }

--- a/cmd/bridge/report.go
+++ b/cmd/bridge/report.go
@@ -17,7 +17,7 @@ import (
 )
 
 // reportSubcommand is a wrapper around the "report" subcommand logic.
-func reportSubcommand(appConfig *config.Config) {
+func reportSubcommand(appConfig *config.Config) error {
 
 	// evaluate all paths building a combined index of all files based on size
 	combinedFileSizeIndex, err := matches.NewFileSizeIndex(
@@ -29,7 +29,11 @@ func reportSubcommand(appConfig *config.Config) {
 
 	if err != nil {
 		if !appConfig.IgnoreErrors {
-			log.Fatalf("Failed to build file size index from paths (%q): %v", appConfig.Paths.String(), err)
+			return fmt.Errorf(
+				"failed to build file size index from paths (%q): %w",
+				appConfig.Paths.String(),
+				err,
+			)
 		}
 		log.Println("Error encountered:", err)
 		log.Println("Attempting to ignore errors as requested")
@@ -41,7 +45,7 @@ func reportSubcommand(appConfig *config.Config) {
 
 	if err := combinedFileSizeIndex.UpdateChecksums(appConfig.IgnoreErrors); err != nil {
 		log.Println("Exiting; error encountered, option to ignore (minor) errors not provided.")
-		os.Exit(1)
+		return err
 	}
 
 	// TODO: Move this to matches package
@@ -54,7 +58,7 @@ func reportSubcommand(appConfig *config.Config) {
 	// Remove FileMatches objects not meeting our file duplicates threshold
 	// value. Remaining FileMatches that meet our file duplicates value are
 	// composed entirely of duplicate files (based on file hash).
-	//log.Println("fileChecksumIndex before pruning:", len(fileChecksumIndex))
+	// log.Println("fileChecksumIndex before pruning:", len(fileChecksumIndex))
 	fileChecksumIndex.PruneFileChecksumIndex(appConfig.FileDuplicatesThreshold)
 
 	// Use text/tabwriter to dump results of the calculations directly to the
@@ -82,7 +86,7 @@ func reportSubcommand(appConfig *config.Config) {
 	// TODO: Implement better error handling
 	if err := fileChecksumIndex.WriteFileMatchesCSV(
 		appConfig.OutputCSVFile, appConfig.BlankLineBetweenSets); err != nil {
-		log.Fatal(err)
+		return err
 	}
 	log.Printf("Successfully created CSV file: %q", appConfig.OutputCSVFile)
 
@@ -90,7 +94,7 @@ func reportSubcommand(appConfig *config.Config) {
 	if appConfig.ExcelFile != "" {
 		// TODO: Implement better error handling
 		if err := fileChecksumIndex.WriteFileMatchesWorkbook(appConfig.ExcelFile, duplicateFiles); err != nil {
-			log.Fatal(err)
+			return err
 		}
 		log.Printf("Successfully created workbook file: %q", appConfig.ExcelFile)
 	}
@@ -102,5 +106,7 @@ func reportSubcommand(appConfig *config.Config) {
 	fmt.Printf("* Run \"%s %s -h\" for a quick list of applicable options\n",
 		os.Args[0], config.PruneSubcommand)
 	fmt.Println("* Read the README for examples, including optional \"backup first\" behavior.")
+
+	return nil
 
 }

--- a/dupesets/dupesets.go
+++ b/dupesets/dupesets.go
@@ -76,10 +76,10 @@ type DuplicateFileSetEntries []DuplicateFileSetEntry
 func (dfsEntries DuplicateFileSetEntries) Print(addSeparatorLine bool) {
 
 	w := &tabwriter.Writer{}
-	//w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, '.', tabwriter.AlignRight|tabwriter.Debug)
+	// w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, '.', tabwriter.AlignRight|tabwriter.Debug)
 
 	// Format in tab-separated columns
-	//w.Init(os.Stdout, 16, 8, 8, '\t', 0)
+	// w.Init(os.Stdout, 16, 8, 8, '\t', 0)
 	w.Init(os.Stdout, 8, 8, 4, '\t', 0)
 
 	// NOTE: Skip outputing size in bytes since this is meant to be reviewed

--- a/matches/matches.go
+++ b/matches/matches.go
@@ -147,19 +147,19 @@ func MergeFileSizeIndexes(fileSizeIndexes ...FileSizeIndex) FileSizeIndex {
 
 	mergedFileSizeIndex := make(FileSizeIndex)
 
-	//log.Printf("Received %d FileSizeIndex objects", len(fileSizeIndexes))
+	// log.Printf("Received %d FileSizeIndex objects", len(fileSizeIndexes))
 
 	// loop over all received FileSizeIndex objects, then out of each FileSizeIndex
 	// object loop over each attached FileMatches object in order to append
 	// each FileMatch in the FileMatches (slice) to our combined object
-	//for counter, fileSizeIndex := range fileSizeIndexes {
+	// for counter, fileSizeIndex := range fileSizeIndexes {
 	for _, fileSizeIndex := range fileSizeIndexes {
 
-		//log.Printf("length of FileSizeIndex %d: %d", counter, len(fileSizeIndex))
+		// log.Printf("length of FileSizeIndex %d: %d", counter, len(fileSizeIndex))
 
 		for fileSize, fileMatches := range fileSizeIndex {
 
-			//log.Printf("length of FileMatches for key %d: %d", fileSize, len(fileMatches))
+			// log.Printf("length of FileMatches for key %d: %d", fileSize, len(fileMatches))
 
 			// From golangci-lint:
 			// matches.go:150:4: should replace loop with mergedFileSizeIndex[fileSize] = append(mergedFileSizeIndex[fileSize], fileMatches...) (S1011)
@@ -170,7 +170,7 @@ func MergeFileSizeIndexes(fileSizeIndexes ...FileSizeIndex) FileSizeIndex {
 		}
 	}
 
-	//log.Printf("mergedFileSizeIndex length: %d", len(mergedFileSizeIndex))
+	// log.Printf("mergedFileSizeIndex length: %d", len(mergedFileSizeIndex))
 
 	return mergedFileSizeIndex
 }
@@ -179,7 +179,7 @@ func MergeFileSizeIndexes(fileSizeIndexes ...FileSizeIndex) FileSizeIndex {
 // FileMatches objects
 func (fi FileSizeIndex) UpdateChecksums(ignoreErrors bool) error {
 
-	//for key, fileMatches := range combinedFileSizeIndex {
+	// for key, fileMatches := range combinedFileSizeIndex {
 	for _, fileMatches := range fi {
 
 		// every key is a file size
@@ -215,7 +215,7 @@ func (fm FileMatches) UpdateChecksums(ignoreErrors bool) error {
 	for index, file := range fm {
 
 		// DEBUG
-		//log.Println("Generating checksum for:", file.FullPath)
+		// log.Println("Generating checksum for:", file.FullPath)
 		result, err := checksums.GenerateCheckSum(file.FullPath)
 		if err != nil {
 
@@ -322,7 +322,7 @@ func ProcessPath(recursiveSearch bool, ignoreErrors bool, fileSizeThreshold int6
 	fileSizeIndex := make(FileSizeIndex)
 	var err error
 
-	//log.Println("RecursiveSearch:", recursiveSearch)
+	// log.Println("RecursiveSearch:", recursiveSearch)
 
 	if recursiveSearch {
 
@@ -555,7 +555,7 @@ func (fi FileChecksumIndex) GetWastedSpace() int64 {
 		wastedSpace += int64(duplicateFileMatchEntries) * fileSize
 	}
 
-	//return wastedSpace, nil
+	// return wastedSpace, nil
 	return wastedSpace
 }
 
@@ -693,7 +693,7 @@ func (fi FileChecksumIndex) WriteFileMatchesWorkbook(filename string, summary Du
 
 	for duplicateFileSetIndex, fileMatches := range fi {
 
-		//sheetHeader := []string{"directory", "file", "size", "checksum"}
+		// sheetHeader := []string{"directory", "file", "size", "checksum"}
 
 		// Create a new sheet for duplicate file metadata
 		duplicateFileSetIndexSheet := duplicateFileSetIndex.String()
@@ -806,7 +806,7 @@ func (fi FileChecksumIndex) WriteFileMatchesCSV(filename string, blankLineBetwee
 		}
 	}()
 
-	//w := csv.NewWriter(os.Stdout)
+	// w := csv.NewWriter(os.Stdout)
 	w := csv.NewWriter(file)
 
 	if err := w.Write(fi.GenerateCSVHeaderRow()); err != nil {
@@ -816,7 +816,7 @@ func (fi FileChecksumIndex) WriteFileMatchesCSV(filename string, blankLineBetwee
 		return err
 	}
 
-	//for key, fileMatches := range fi {
+	// for key, fileMatches := range fi {
 	for _, fileMatches := range fi {
 
 		// This can be useful when focusing just on the sets themselves.
@@ -857,10 +857,10 @@ func (fi FileChecksumIndex) WriteFileMatchesCSV(filename string, blankLineBetwee
 func (fi FileChecksumIndex) PrintFileMatches(blankLineBetweenSets bool) {
 
 	w := new(tabwriter.Writer)
-	//w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, '.', tabwriter.AlignRight|tabwriter.Debug)
+	// w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, '.', tabwriter.AlignRight|tabwriter.Debug)
 
 	// Format in tab-separated columns
-	//w.Init(os.Stdout, 16, 8, 8, '\t', 0)
+	// w.Init(os.Stdout, 16, 8, 8, '\t', 0)
 	w.Init(os.Stdout, 8, 8, 4, '\t', 0)
 
 	// Header row in output
@@ -901,7 +901,7 @@ func (fi FileChecksumIndex) PrintFileMatches(blankLineBetweenSets bool) {
 func (dfs DuplicateFilesSummary) PrintSummary() {
 
 	w := new(tabwriter.Writer)
-	//w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, '.', tabwriter.AlignRight|tabwriter.Debug)
+	// w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, '.', tabwriter.AlignRight|tabwriter.Debug)
 
 	// Format in tab-separated columns
 	w.Init(os.Stdout, 8, 8, 5, '\t', 0)

--- a/paths/paths.go
+++ b/paths/paths.go
@@ -36,7 +36,7 @@ func PathExists(path string) bool {
 
 	// https://gist.github.com/mattes/d13e273314c3b3ade33f
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
-		//log.Println("path found")
+		// log.Println("path found")
 		return true
 	}
 
@@ -148,7 +148,7 @@ func CreateBackupDirectoryTree(filename string, fullPathToBackupDir string) (str
 	}
 
 	// DEBUG
-	//fmt.Printf("Calling os.MkdirAll(%v, %v)\n", targetBackupDirPath, defaultDirectoryPerms)
+	// fmt.Printf("Calling os.MkdirAll(%v, %v)\n", targetBackupDirPath, defaultDirectoryPerms)
 
 	if err := os.MkdirAll(targetBackupDirPath, defaultDirectoryPerms); err != nil {
 		return "", fmt.Errorf("failed to create fully-qualified backup path %q for %q: %s",


### PR DESCRIPTION
- commentFormatting
  - minor whitespace tweaks

- exitAfterDefer
  - legitimate complaint
  - fixed by using an initial defer of a pointer to int with
    a default value that indicates success. This can be
    overridden as needed to indicate application failure
    without blocking other deferred functions from running.
    Also related, I modified the subcommand "wrapper" functions
    to return an error and used that from main func to process
    messages instead of logging errors and failing the app
    from within the wrapper functions.

Further cleanup and refactoring is still needed, but deferred (ha) until a later time.