### PR TITLE
Fix explicit exit code handling

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -23,14 +23,14 @@ func main() {
 	// default exit code that matches expectations, but allow explicitly
 	// setting the exit code in such a way that is compatible with using
 	// deferred function calls throughout the application.
-	var appExitCode *int
+	var appExitCode int
 	defer func(code *int) {
 		var exitCode int
 		if code != nil {
 			exitCode = *code
 		}
 		os.Exit(exitCode)
-	}(appExitCode)
+	}(&appExitCode)
 
 	var appConfig *config.Config
 	var err error
@@ -41,11 +41,11 @@ func main() {
 		// sufficient enough
 		// if errors.Is(err, config.ErrMissingSubcommand) || errors.Is(err, flag.ErrHelp) {
 		if errors.Is(err, flag.ErrHelp) {
-			*appExitCode = 0
+			appExitCode = 0
 			return
 		}
 		fmt.Printf("\nERROR: %s\n", err)
-		*appExitCode = 1
+		appExitCode = 1
 		return
 	}
 
@@ -60,7 +60,7 @@ func main() {
 		fmt.Printf("subcommand '%s' called\n", config.PruneSubcommand)
 
 		if err := pruneSubcommand(appConfig); err != nil {
-			*appExitCode = 1
+			appExitCode = 1
 			fmt.Println(err)
 			return
 		}
@@ -70,7 +70,7 @@ func main() {
 		fmt.Printf("subcommand '%s' called\n", config.ReportSubcommand)
 
 		if err := reportSubcommand(appConfig); err != nil {
-			*appExitCode = 1
+			appExitCode = 1
 			fmt.Println(err)
 			return
 		}
@@ -78,7 +78,7 @@ func main() {
 	// We should not be able to reach this section
 	default:
 		log.Printf("invalid subcommand: %s", os.Args[1])
-		*appExitCode = 1
+		appExitCode = 1
 		return
 	}
 


### PR DESCRIPTION
Avoid assignment to uninitialized pointer by using a value
type and explicitly passing a reference to the value type
into the deferred anonymous function. This allows the
intended behavior to work as expected.

refs GH-117