### PR TITLE
Ignore false-positive gosec G307 linting errors

### DIFF
--- a/checksums/checksums.go
+++ b/checksums/checksums.go
@@ -67,6 +67,10 @@ func GenerateCheckSum(file string) (SHA256Checksum, error) {
 	}
 
 	// Note the duplicate f.Close() call at end of function and why
+	//
+	// #nosec G307
+	// Believed to be a false-positive from recent gosec release
+	// https://github.com/securego/gosec/issues/714
 	defer func() {
 		if err := f.Close(); err != nil {
 			log.Printf(

--- a/cmd/bridge/prune.go
+++ b/cmd/bridge/prune.go
@@ -30,6 +30,11 @@ func pruneSubcommand(appConfig *config.Config) error {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	// #nosec G307
+	// Believed to be a false-positive from recent gosec release
+	// https://github.com/securego/gosec/issues/714
+	//
 	// NOTE: We're not manipulating contents for this file, so relying solely
 	// on a defer statement to close the file should be sufficient?
 	defer func() {

--- a/matches/matches.go
+++ b/matches/matches.go
@@ -796,6 +796,10 @@ func (fi FileChecksumIndex) WriteFileMatchesCSV(filename string, blankLineBetwee
 	if err != nil {
 		return err
 	}
+
+	// #nosec G307
+	// Believed to be a false-positive from recent gosec release
+	// https://github.com/securego/gosec/issues/714
 	defer func() {
 		if err := file.Close(); err != nil {
 			log.Printf(

--- a/paths/paths.go
+++ b/paths/paths.go
@@ -204,6 +204,10 @@ func BackupFile(sourceFilename string, destinationDirectory string) error {
 		return fmt.Errorf("unable to create new backup file %q: %s",
 			destinationFile, err)
 	}
+
+	// #nosec G307
+	// Believed to be a false-positive from recent gosec release
+	// https://github.com/securego/gosec/issues/714
 	defer func() {
 		if err := destinationFileHandle.Close(); err != nil {
 			log.Printf(
@@ -233,6 +237,10 @@ func BackupFile(sourceFilename string, destinationDirectory string) error {
 		return fmt.Errorf("unable to open source file %q in order to create backup copy: %s",
 			sourceFilename, err)
 	}
+
+	// #nosec G307
+	// Believed to be a false-positive from recent gosec release
+	// https://github.com/securego/gosec/issues/714
 	defer func() {
 		if err := sourceFileHandle.Close(); err != nil {
 			log.Printf(


### PR DESCRIPTION
Issues reported after upgrading golangci-lint to v1.43.0.
gosec was updated in that version from v2.8.1 to v2.9.1.

fixes atc0005/bridge#161
refs golangci/golangci-lint#2299