### PR TITLE
Fix linting errors

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -45,7 +45,7 @@ const ReportSubcommand string = "report"
 // path to this variable, including the package. We set a placeholder value so
 // that something resembling a version string will be provided for
 // non-Makefile builds.
-var version string = "x.y.z"
+var version = "x.y.z"
 
 const myAppName string = "bridge"
 const myAppURL string = "https://github.com/atc0005/bridge"

--- a/matches/matches.go
+++ b/matches/matches.go
@@ -788,11 +788,11 @@ func (fi FileChecksumIndex) WriteFileMatchesWorkbook(filename string, summary Du
 // to the specified CSV file.
 func (fi FileChecksumIndex) WriteFileMatchesCSV(filename string, blankLineBetweenSets bool) error {
 
-	if !paths.PathExists(filepath.Dir(filename)) {
+	if !paths.PathExists(filepath.Dir(filepath.Clean(filename))) {
 		return fmt.Errorf("parent directory for specified CSV file to create does not exist")
 	}
 
-	file, err := os.Create(filename)
+	file, err := os.Create(filepath.Clean(filename))
 	if err != nil {
 		return err
 	}

--- a/paths/paths.go
+++ b/paths/paths.go
@@ -199,7 +199,7 @@ func BackupFile(sourceFilename string, destinationDirectory string) error {
 		)
 	}
 
-	destinationFileHandle, err := os.Create(destinationFile)
+	destinationFileHandle, err := os.Create(filepath.Clean(destinationFile))
 	if err != nil {
 		return fmt.Errorf("unable to create new backup file %q: %s",
 			destinationFile, err)


### PR DESCRIPTION
- gosec errors regarding file inclusion via variable
  - this is intentional behavior, but we attempt to remediate
    any potential problems via filepath.Clean()
- revive error regarding being too explicit with declared
  variable type

fixes GH-177