### PR TITLE
Update project to Go 1.19

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -81,5 +81,5 @@ updates:
         versions:
           # Ignore updates from series associated with the latest "stable"
           # Go release and no longer supported Go versions.
-          - ">= 1.18"
-          - "< 1.17"
+          - ">= 1.20"
+          - "< 1.19"

--- a/dependabot/docker/go/Dockerfile
+++ b/dependabot/docker/go/Dockerfile
@@ -15,4 +15,4 @@
 # binaries) to reflect that version of Go.
 
 # https://hub.docker.com/_/golang
-FROM golang:1.17.13
+FROM golang:1.19.0

--- a/doc.go
+++ b/doc.go
@@ -1,14 +1,13 @@
 /*
-
 bridge is a small CLI utility used to find duplicate files.
 
-PROJECT HOME
+# Project Home
 
 See our GitHub repo (https://github.com/atc0005/bridge) for the latest
 code, to file an issue or submit improvements for review and potential
 inclusion into the project.
 
-PURPOSE
+# Purpose
 
 bridge is intended for locating duplicate files across one or many paths. The
 inspiration was managing digital photos collected in date-based folders as
@@ -16,96 +15,20 @@ well as event-based folders. Often we would gather folders together in
 "collections" for processing and unintentionally duplicate the existing images
 already sorted by date.
 
-FEATURES
+# Features
 
-• single binary, no outside dependencies
+  - single binary, no outside dependencies
+  - minimal configuration
+  - very few build dependencies
+  - shallow or recursive processing across one or more paths
+  - matches initially based on file size, confirm via file hash
+  - generate CSV report of all duplicate file matches
+  - (optionally) generate Microsoft Excel workbook of all duplicate file matches
+  - generate (rough) console equivalent of CSV file for quick review
+  - (optionally) remove user-flagged duplicate files using a previously generated CSV report
 
-• minimal configuration
+# Usage
 
-• very few build dependencies
-
-• shallow or recursive processing across one or more paths
-
-• matches initially based on file size, confirm via file hash
-
-• generate CSV report of all duplicate file matches
-
-• (optionally) generate Microsoft Excel workbook of all duplicate file matches
-
-• generate (rough) console equivalent of CSV file for quick review
-
-• (optionally) remove user-flagged duplicate files using a previously generated CSV report
-
-USAGE
-
-Help output is below. See the README for examples.
-
-$ ./bridge -h
-
-    bridge x.y.z
-    https://github.com/atc0005/bridge
-
-    Available subcommands:
-            prune
-            report
-
-    See available options for each subcommand by running:
-            bridge prune -h
-            bridge report -h
-
-    DEBUG: Help flags used
-
-    ERROR: missing subcommand
-
-
-$ ./bridge report -h
-
-    DEBUG: subcommand 'report'
-
-    bridge x.y.z
-    https://github.com/atc0005/bridge
-
-    Usage of "bridge report":
-    -console
-            Dump (approximate) CSV file equivalent to console.
-    -csvfile string
-            The (required) fully-qualified path to a CSV file that this application should generate.
-    -duplicates int
-            Number of files of the same file size needed before duplicate validation logic is applied. (default 2)
-    -excelfile string
-            The (optional) fully-qualified path to an Excel file that this application should generate.
-    -ignore-errors
-            Ignore minor errors whenever possible. This option does not affect handling of fatal errors such as failure to generate output report files.
-    -path value
-            Path to process. This flag may be repeated for each additional path to evaluate.
-    -recurse
-            Perform recursive search into subdirectories per provided path.
-    -size int
-            File size limit (in bytes) for evaluation. Files smaller than this will be skipped. (default 1)
-    DEBUG: err returned from reportCmd.Parse(): flag: help requested
-
-$ ./bridge prune -h
-
-    DEBUG: subcommand 'prune'
-
-    bridge x.y.z
-    https://github.com/atc0005/bridge
-
-    Usage of "bridge prune":
-    -backup-dir string
-            The writable directory path where files should be relocated instead of removing them. The original path structure will be created starting with the specified path as the root.
-    -blank-line
-            Add a blank line between sets of matching files in console and file output.
-    -console
-            Dump (approximate) CSV file equivalent to console.
-    -dry-run
-            Don't actually remove files. Echo what would have been done to stdout.
-    -ignore-errors
-            Ignore minor errors whenever possible. This option does not affect handling of fatal errors such as failure to generate output report files.
-    -input-csvfile string
-            The fully-qualified path to a CSV file that this application should use for file removal decisions.
-    -use-first-row
-            Attempt to use the first row of the input file. Normally this row is skipped since it is usually the header row and not duplicate file data.
-    DEBUG: err returned from pruneCmd.Parse(): flag: help requested
+See our main README for supported settings and examples.
 */
 package main

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/atc0005/bridge
 
-go 1.17
+go 1.19
 
 require github.com/360EntSecGroup-Skylar/excelize/v2 v2.4.0
 


### PR DESCRIPTION
- update go.mod file from Go 1.17 to 1.19
- update doc.go file to use Go 1.19 package doc comments syntax
- update "Canary" Dockerfile to reflect current Go 1.19 version
- update Dependabot configuration for Dockerfile to ignore Go releases
  outside of the Go 1.19 release series