### PR TITLE
linting-fixes-for-go-1.19-release

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -23,9 +23,11 @@ import (
 // ErrInvalidSubcommand represents cases where the user did not pass a valid
 // subcommand
 // var ErrInvalidSubcommand = fmt.Errorf(
-// 	"expected '%s' or '%s' subcommands",
-// 	PruneSubcommand,
-// 	ReportSubcommand,
+//
+//	"expected '%s' or '%s' subcommands",
+//	PruneSubcommand,
+//	ReportSubcommand,
+//
 // )
 var ErrInvalidSubcommand = errors.New("invalid subcommand")
 


### PR DESCRIPTION
- Go doc comment formatting fixes
- Swap io/ioutil package for io package
  - including updates to handle change from working with
    []fs.FileInfo type to []os.DirEntry type