### PR TITLE
Add missing cmd doc file

### DIFF
--- a/cmd/bridge/doc.go
+++ b/cmd/bridge/doc.go
@@ -1,0 +1,22 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/bridge
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+// bridge is intended for locating duplicate files across one or many paths.
+// The inspiration was managing digital photos collected in date-based folders
+// as well as event-based folders. Often we would gather folders together in
+// "collections" for processing and unintentionally duplicate the existing
+// images already sorted by date.
+//
+// See our [GitHub repo]:
+//
+//   - to review documentation (including examples)
+//   - for the latest code
+//   - to file an issue or submit improvements for review and potential
+//     inclusion into the project
+//
+// [GitHub repo]: https://github.com/atc0005/bridge
+package main


### PR DESCRIPTION
Add "package" doc file to resolve revive `package-comment`
linting error surfaced by recent linter update.