### PR TITLE
Ignore os.ErrClosed errors on deferred file close

### DIFF
--- a/checksums/checksums.go
+++ b/checksums/checksums.go
@@ -11,6 +11,7 @@ package checksums
 
 import (
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -67,17 +68,16 @@ func GenerateCheckSum(file string) (SHA256Checksum, error) {
 	}
 
 	// Note the duplicate f.Close() call at end of function and why
-	//
-	// #nosec G307
-	// Believed to be a false-positive from recent gosec release
-	// https://github.com/securego/gosec/issues/714
 	defer func() {
 		if err := f.Close(); err != nil {
-			log.Printf(
-				"error occurred closing file %q: %v",
-				file,
-				err,
-			)
+			// Ignore "file already closed" errors
+			if !errors.Is(err, os.ErrClosed) {
+				log.Printf(
+					"error occurred closing file %q: %v",
+					file,
+					err,
+				)
+			}
 		}
 	}()
 


### PR DESCRIPTION
Not explicitly ignoring this error leads to a lot of noise during normal operation.

NOTE: Also remove explicit disabling of G307 linter rule since the original problem noted on upstream issue 714 appears to be resolved.

fixes GH-208