### PR TITLE
Fix workflow job id values

### DIFF
--- a/.github/workflows/scheduled-monthly.yml
+++ b/.github/workflows/scheduled-monthly.yml
@@ -16,6 +16,6 @@ on:
     - cron: "30 4 1 * *"
 
 jobs:
-  lint:
+  monthly:
     name: Monthly Tasks
     uses: atc0005/shared-project-resources/.github/workflows/scheduled-monthly.yml@master

--- a/.github/workflows/scheduled-weekly.yml
+++ b/.github/workflows/scheduled-weekly.yml
@@ -16,6 +16,6 @@ on:
     - cron: "30 4 * * 0"
 
 jobs:
-  lint:
+  weekly:
     name: Weekly Tasks
     uses: atc0005/shared-project-resources/.github/workflows/scheduled-weekly.yml@master


### PR DESCRIPTION
The newly added `scheduled-*.yml` files reused job id values from the templates that they were based off of. They have been adjusted to reflect the schedule.

refs atc0005/shared-project-resources#68