### PR TITLE
Fix errwrap linting errors

### DIFF
--- a/internal/dupesets/dupesets.go
+++ b/internal/dupesets/dupesets.go
@@ -171,7 +171,11 @@ func (dfsEntry *DuplicateFileSetEntry) UpdateSizeInfo() error {
 		// checksum validation
 		fileInfo, err := os.Stat(fileFullPath)
 		if err != nil {
-			return fmt.Errorf("unable to stat %q to determine size in bytes", fileFullPath)
+			return fmt.Errorf(
+				"unable to stat %q to determine size in bytes: %w",
+				fileFullPath,
+				err,
+			)
 		}
 		dfsEntry.SizeInBytes = fileInfo.Size()
 	}
@@ -211,7 +215,7 @@ func ValidateInputRow(dfsEntry DuplicateFileSetEntry, rowNum int) error {
 	// file exists, verify checksum before proceeding further
 	if err := dfsEntry.Checksum.Verify(fileFullPath); err != nil {
 		return fmt.Errorf(
-			"checksum validation failed for %q: %s", fileFullPath, err)
+			"checksum validation failed for %q: %w", fileFullPath, err)
 	}
 
 	// TODO: Any validation needed against the RemoveFile field? At this point
@@ -274,7 +278,7 @@ func ParseInputRow(row []string, fieldCount int, rowNum int) (DuplicateFileSetEn
 		sizeInBytes, err = strconv.ParseInt(row[3], 10, 64)
 		if err != nil {
 			log.Printf("DEBUG | CSV row %d, field %d: %q\n", rowNum, 4, row[3])
-			return dfsEntry, fmt.Errorf("failed to convert CSV sizeInBytes field %v", err)
+			return dfsEntry, fmt.Errorf("failed to convert CSV sizeInBytes field: %w", err)
 		}
 	}
 
@@ -294,7 +298,7 @@ func ParseInputRow(row []string, fieldCount int, rowNum int) (DuplicateFileSetEn
 		removeFile, err = strconv.ParseBool(row[5])
 		if err != nil {
 			log.Printf("DEBUG | CSV row %d, field %d: %q\n", rowNum, 6, row[5])
-			return dfsEntry, fmt.Errorf("failed to convert CSV remove_file field %v", err)
+			return dfsEntry, fmt.Errorf("failed to convert CSV remove_file field: %w", err)
 		}
 	}
 

--- a/internal/matches/matches.go
+++ b/internal/matches/matches.go
@@ -299,7 +299,7 @@ func NewFileSizeIndex(recursiveSearch bool, ignoreErrors bool, fileSizeThreshold
 		// TODO: Call ProcessPath here
 		fileSizeIndex, err := ProcessPath(recursiveSearch, ignoreErrors, fileSizeThreshold, path)
 		if err != nil {
-			return nil, fmt.Errorf("failed to process path %q: %v", path, err)
+			return nil, fmt.Errorf("failed to process path %q: %w", path, err)
 		}
 
 		// FIXME: This needs to occur at the end of each loop?
@@ -848,14 +848,14 @@ func (fi FileChecksumIndex) WriteFileMatchesCSV(filename string, blankLineBetwee
 		if blankLineBetweenSets {
 			if err := w.Write(fileMatches.GenerateEmptyCSVDataRow()); err != nil {
 				// TODO: Use error wrapping instead?
-				return fmt.Errorf("error writing record to csv: %v", err)
+				return fmt.Errorf("error writing record to csv: %w", err)
 			}
 		}
 
 		for _, file := range fileMatches {
 			if err := w.Write(file.GenerateCSVDataRow()); err != nil {
 				// TODO: Use error wrapping instead?
-				return fmt.Errorf("error writing record to csv: %v", err)
+				return fmt.Errorf("error writing record to csv: %w", err)
 			}
 		}
 

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -57,7 +57,7 @@ func RemoveFile(filename string, dryRun bool) error {
 	log.Printf("File removal enabled, attempting to remove %q\n", filename)
 	err := os.Remove(filename)
 	if err != nil {
-		return fmt.Errorf("error encountered while removing %q: %s", filename, err)
+		return fmt.Errorf("error encountered while removing %q: %w", filename, err)
 	}
 
 	log.Printf("Successfully removed %q\n", filename)
@@ -72,7 +72,7 @@ func GetBackupTargetDir(filename string, fullPathToBackupDir string) (string, er
 
 	fullPathToFile, err := filepath.Abs(filename)
 	if err != nil {
-		return "", fmt.Errorf("unable to determine absolute path to %q: %s",
+		return "", fmt.Errorf("unable to determine absolute path to %q: %w",
 			filename,
 			err,
 		)
@@ -151,7 +151,7 @@ func CreateBackupDirectoryTree(filename string, fullPathToBackupDir string) (str
 	// fmt.Printf("Calling os.MkdirAll(%v, %v)\n", targetBackupDirPath, defaultDirectoryPerms)
 
 	if err := os.MkdirAll(targetBackupDirPath, defaultDirectoryPerms); err != nil {
-		return "", fmt.Errorf("failed to create fully-qualified backup path %q for %q: %s",
+		return "", fmt.Errorf("failed to create fully-qualified backup path %q for %q: %w",
 			targetBackupDirPath,
 			filename,
 			err,
@@ -175,7 +175,7 @@ func BackupFile(sourceFilename string, destinationDirectory string) error {
 	targetBackupDirPath, err := CreateBackupDirectoryTree(sourceFilename, destinationDirectory)
 	if err != nil {
 		return fmt.Errorf(
-			"failed to create directory %q in order to backup %q: %s",
+			"failed to create directory %q in order to backup %q: %w",
 			sourceFilename,
 			targetBackupDirPath,
 			err,
@@ -201,7 +201,7 @@ func BackupFile(sourceFilename string, destinationDirectory string) error {
 
 	destinationFileHandle, err := os.Create(filepath.Clean(destinationFile))
 	if err != nil {
-		return fmt.Errorf("unable to create new backup file %q: %s",
+		return fmt.Errorf("unable to create new backup file %q: %w",
 			destinationFile, err)
 	}
 
@@ -234,7 +234,7 @@ func BackupFile(sourceFilename string, destinationDirectory string) error {
 
 	sourceFileHandle, err := os.Open(filepath.Clean(sourceFilename))
 	if err != nil {
-		return fmt.Errorf("unable to open source file %q in order to create backup copy: %s",
+		return fmt.Errorf("unable to open source file %q in order to create backup copy: %w",
 			sourceFilename, err)
 	}
 
@@ -255,7 +255,7 @@ func BackupFile(sourceFilename string, destinationDirectory string) error {
 	if err != nil {
 		// copy failed, we should cleanup here
 		log.Printf("failed to copy %q to %q: %s\n", sourceFilename, destinationFile, err)
-		return fmt.Errorf("failed to copy %q to %q: %s", sourceFilename, destinationFile, err)
+		return fmt.Errorf("failed to copy %q to %q: %w", sourceFilename, destinationFile, err)
 	}
 
 	// I encountered this when I unintentionally switched the dest/source
@@ -286,7 +286,7 @@ func BackupFile(sourceFilename string, destinationDirectory string) error {
 
 	if err := destinationFileHandle.Sync(); err != nil {
 		return fmt.Errorf(
-			"failed to explicitly sync file %q after backup attempt: %s",
+			"failed to explicitly sync file %q after backup attempt: %w",
 			destinationFile,
 			err,
 		)
@@ -294,7 +294,7 @@ func BackupFile(sourceFilename string, destinationDirectory string) error {
 
 	if err := sourceFileHandle.Close(); err != nil {
 		return fmt.Errorf(
-			"failed to close original file %q after backup attempt: %s",
+			"failed to close original file %q after backup attempt: %w",
 			sourceFilename,
 			err,
 		)


### PR DESCRIPTION
Replace use of '%s' and '%v' formatting verbs with '%w' to return wrapped errors.