### PR TITLE
Releases: Update 'Bug Fixes' label

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -23,7 +23,7 @@ changelog:
         - enhancement
     - title: Bug Fixes 🐛
       labels:
-        - bug-fix
+        - bug
     - title: Dependency Updates
       labels:
         - dependencies


### PR DESCRIPTION
Use 'bug' instead of 'bug-fix' to match the pattern used by this project.