### PR TITLE
Update xuri/efp and xuri/nfp dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/richardlehane/mscfb v1.0.4 // indirect
 	github.com/richardlehane/msoleps v1.0.3 // indirect
-	github.com/xuri/efp v0.0.0-20230802181842-ad255f2331ca // indirect
-	github.com/xuri/nfp v0.0.0-20230819163627-dc951e3ffe1a // indirect
+	github.com/xuri/efp v0.0.0-20231025114914-d1ff6096ae53 // indirect
+	github.com/xuri/nfp v0.0.0-20230919160717-d98342af3f05 // indirect
 	golang.org/x/crypto v0.15.0 // indirect
 	golang.org/x/net v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -15,12 +15,14 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/xuri/efp v0.0.0-20230802181842-ad255f2331ca h1:uvPMDVyP7PXMMioYdyPH+0O+Ta/UO1WFfNYMO3Wz0eg=
 github.com/xuri/efp v0.0.0-20230802181842-ad255f2331ca/go.mod h1:ybY/Jr0T0GTCnYjKqmdwxyxn2BQf2RcQIIvex5QldPI=
+github.com/xuri/efp v0.0.0-20231025114914-d1ff6096ae53 h1:Chd9DkqERQQuHpXjR/HSV1jLZA6uaoiwwH3vSuF3IW0=
+github.com/xuri/efp v0.0.0-20231025114914-d1ff6096ae53/go.mod h1:ybY/Jr0T0GTCnYjKqmdwxyxn2BQf2RcQIIvex5QldPI=
 github.com/xuri/excelize/v2 v2.8.0 h1:Vd4Qy809fupgp1v7X+nCS/MioeQmYVVzi495UCTqB7U=
 github.com/xuri/excelize/v2 v2.8.0/go.mod h1:6iA2edBTKxKbZAa7X5bDhcCg51xdOn1Ar5sfoXRGrQg=
-github.com/xuri/nfp v0.0.0-20230819163627-dc951e3ffe1a h1:Mw2VNrNNNjDtw68VsEj2+st+oCSn4Uz7vZw6TbhcV1o=
 github.com/xuri/nfp v0.0.0-20230819163627-dc951e3ffe1a/go.mod h1:WwHg+CVyzlv/TX9xqBFXEZAuxOPxn2k1GNHwG41IIUQ=
+github.com/xuri/nfp v0.0.0-20230919160717-d98342af3f05 h1:qhbILQo1K3mphbwKh1vNm4oGezE1eF9fQWmNiIpSfI4=
+github.com/xuri/nfp v0.0.0-20230919160717-d98342af3f05/go.mod h1:WwHg+CVyzlv/TX9xqBFXEZAuxOPxn2k1GNHwG41IIUQ=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=

--- a/vendor/github.com/xuri/nfp/nfp.go
+++ b/vendor/github.com/xuri/nfp/nfp.go
@@ -365,10 +365,6 @@ func (ps *Parser) getTokens() Tokens {
 					ps.Tokens.add(ps.Token.TValue, ps.Token.TType, ps.Token.Parts)
 					ps.Token = Token{}
 				}
-				if ps.Token.TValue != "" && !strings.ContainsAny(NumCodeChars, ps.Token.TValue) {
-					ps.Tokens.add(ps.Token.TValue, TokenTypeLiteral, ps.Token.Parts)
-					ps.Token = Token{}
-				}
 				ps.Token.TType = TokenTypeZeroPlaceHolder
 				if ps.currentChar() != Zero {
 					ps.Token.TType = TokenTypeLiteral
@@ -396,6 +392,13 @@ func (ps *Parser) getTokens() Tokens {
 				if ps.Token.TType == TokenTypeZeroPlaceHolder || ps.Token.TType == TokenTypeHashPlaceHolder {
 					ps.Tokens.add(ps.Token.TValue, ps.Token.TType, ps.Token.Parts)
 					ps.Tokens.add(ps.currentChar(), TokenTypeDecimalPoint, ps.Token.Parts)
+					ps.Token = Token{}
+					ps.Offset++
+					continue
+				}
+				if ps.Token.TType == TokenTypeDateTimes && !strings.ContainsAny(NumCodeChars, ps.nextChar()) {
+					ps.Tokens.add(ps.Token.TValue, ps.Token.TType, ps.Token.Parts)
+					ps.Tokens.add(ps.currentChar(), TokenTypeLiteral, ps.Token.Parts)
 					ps.Token = Token{}
 					ps.Offset++
 					continue
@@ -509,13 +512,6 @@ func (ps *Parser) getTokens() Tokens {
 		}
 
 		if ps.currentChar() == Whitespace {
-			if inStrSlice(AmPm, ps.Token.TValue, false) != -1 {
-				ps.Token.TType = TokenTypeDateTimes
-				ps.Tokens.add(ps.Token.TValue, ps.Token.TType, ps.Token.Parts)
-				ps.Token = Token{}
-				ps.Offset++
-				continue
-			}
 			if ps.Token.TType != "" && ps.Token.TType != TokenTypeLiteral {
 				ps.Tokens.add(ps.Token.TValue, ps.Token.TType, ps.Token.Parts)
 			}
@@ -580,9 +576,6 @@ func (ps *Parser) getTokens() Tokens {
 		}
 
 		if ps.currentChar() == BracketOpen {
-			if ps.Token.TType == "" && ps.Token.TValue != "" {
-				ps.Token.TType = TokenTypeLiteral
-			}
 			if ps.Token.TType != "" && !ps.InBracket {
 				ps.Tokens.add(ps.Token.TValue, ps.Token.TType, ps.Token.Parts)
 				ps.Token = Token{}
@@ -700,9 +693,18 @@ func (ps *Parser) getTokens() Tokens {
 			if !strings.ContainsAny(NumCodeChars, ps.currentChar()) && ps.Token.TType == TokenTypeZeroPlaceHolder {
 				ps.Tokens.add(ps.Token.TValue, ps.Token.TType, ps.Token.Parts)
 				ps.Token = Token{}
+				continue
 			}
+			ps.Token.TType = TokenTypeLiteral
 		}
 		ps.Token.TValue += ps.currentChar()
+		if inStrSlice(AmPm, ps.Token.TValue, false) != -1 {
+			ps.Token.TType = TokenTypeDateTimes
+			ps.Tokens.add(ps.Token.TValue, ps.Token.TType, ps.Token.Parts)
+			ps.Token = Token{}
+			ps.Offset++
+			continue
+		}
 		ps.Offset++
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -7,13 +7,13 @@ github.com/richardlehane/mscfb
 # github.com/richardlehane/msoleps v1.0.3
 ## explicit
 github.com/richardlehane/msoleps/types
-# github.com/xuri/efp v0.0.0-20230802181842-ad255f2331ca
+# github.com/xuri/efp v0.0.0-20231025114914-d1ff6096ae53
 ## explicit; go 1.11
 github.com/xuri/efp
 # github.com/xuri/excelize/v2 v2.8.0
 ## explicit; go 1.16
 github.com/xuri/excelize/v2
-# github.com/xuri/nfp v0.0.0-20230819163627-dc951e3ffe1a
+# github.com/xuri/nfp v0.0.0-20230919160717-d98342af3f05
 ## explicit; go 1.15
 github.com/xuri/nfp
 # golang.org/x/crypto v0.15.0


### PR DESCRIPTION
Changes:

- xuri/efp
  - `v0.0.0-20230802181842-ad255f2331ca` to `v0.0.0-20231025114914-d1ff6096ae53`
- xuri/nfp
  - `v0.0.0-20230802015359-2d5eeba905e9` to `v0.0.0-20230919160717-d98342af3f05`

Applied via:

go get -u ./...
go mod tidy
go mod vendor