### PR TITLE
Fix errcheck linting errors

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -94,7 +94,7 @@ func (i *multiValueFlag) Set(value string) error {
 
 // Branding is responsible for emitting application name, version and origin
 func Branding() {
-	fmt.Fprintf(flag.CommandLine.Output(), "\n%s %s\n%s\n\n", myAppName, version, myAppURL)
+	_, _ = fmt.Fprintf(flag.CommandLine.Output(), "\n%s %s\n%s\n\n", myAppName, version, myAppURL)
 }
 
 // MainCmdUsage is meant to be called whenever a valid subcommand is missing
@@ -107,16 +107,16 @@ func MainCmdUsage(subCmds ...string) func() {
 
 		Branding()
 
-		fmt.Fprintln(flag.CommandLine.Output(), "Available subcommands:")
+		_, _ = fmt.Fprintln(flag.CommandLine.Output(), "Available subcommands:")
 		for _, subCmd := range subCmds {
-			fmt.Fprintf(flag.CommandLine.Output(), "\t%s\n", subCmd)
+			_, _ = fmt.Fprintf(flag.CommandLine.Output(), "\t%s\n", subCmd)
 		}
-		fmt.Fprintln(flag.CommandLine.Output(), "")
-		fmt.Fprintln(flag.CommandLine.Output(), "See available options for each subcommand by running:")
+		_, _ = fmt.Fprintln(flag.CommandLine.Output(), "")
+		_, _ = fmt.Fprintln(flag.CommandLine.Output(), "See available options for each subcommand by running:")
 		for _, subCmd := range subCmds {
-			fmt.Fprintf(flag.CommandLine.Output(), "\t%s %s -h\n", myBinaryName, subCmd)
+			_, _ = fmt.Fprintf(flag.CommandLine.Output(), "\t%s %s -h\n", myBinaryName, subCmd)
 		}
-		fmt.Fprintln(flag.CommandLine.Output(), "")
+		_, _ = fmt.Fprintln(flag.CommandLine.Output(), "")
 	}
 
 }
@@ -132,7 +132,7 @@ func SubcommandUsage(flagSet *flag.FlagSet) func() {
 
 		Branding()
 
-		fmt.Fprintf(flag.CommandLine.Output(), "Usage of \"%s %s\":\n",
+		_, _ = fmt.Fprintf(flag.CommandLine.Output(), "Usage of \"%s %s\":\n",
 			myBinaryName,
 			flagSet.Name(),
 		)

--- a/internal/dupesets/dupesets.go
+++ b/internal/dupesets/dupesets.go
@@ -92,7 +92,7 @@ func (dfsEntries DuplicateFileSetEntries) Print(addSeparatorLine bool) {
 		TabWriterChecksumColumnHeaderName,
 		TabWriterRemoveFileColumnHeaderName,
 	)
-	fmt.Fprintln(w, headerRow)
+	_, _ = fmt.Fprintln(w, headerRow)
 
 	var lastChecksum checksums.SHA256Checksum
 	var entriesCtr int
@@ -103,7 +103,7 @@ func (dfsEntries DuplicateFileSetEntries) Print(addSeparatorLine bool) {
 		// using len() builtin.
 		entriesCtr++
 
-		fmt.Fprintf(w,
+		_, _ = fmt.Fprintf(w,
 			"%v\t%v\t%v\t%v\t%v\n",
 			row.ParentDirectory,
 			row.Filename,
@@ -119,7 +119,7 @@ func (dfsEntries DuplicateFileSetEntries) Print(addSeparatorLine bool) {
 		// line for the first item.
 		if addSeparatorLine && entriesCtr != 1 {
 			if lastChecksum != row.Checksum {
-				fmt.Fprintf(w, "\n")
+				_, _ = fmt.Fprintf(w, "\n")
 			}
 		}
 
@@ -129,7 +129,7 @@ func (dfsEntries DuplicateFileSetEntries) Print(addSeparatorLine bool) {
 
 	}
 
-	fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w)
 	if err := w.Flush(); err != nil {
 		log.Printf(
 			"error occurred flushing tabwriter: %v",

--- a/internal/matches/matches.go
+++ b/internal/matches/matches.go
@@ -889,13 +889,13 @@ func (fi FileChecksumIndex) PrintFileMatches(blankLineBetweenSets bool) {
 	w.Init(os.Stdout, 8, 8, 4, '\t', 0)
 
 	// Header row in output
-	fmt.Fprintln(w,
+	_, _ = fmt.Fprintln(w,
 		"Directory\tFile\tSize\tChecksum\t")
 	for _, fileMatches := range fi {
 		for _, file := range fileMatches {
 
 			// TODO: Confirm that newline between file sets is useful
-			fmt.Fprintf(w,
+			_, _ = fmt.Fprintf(w,
 				"%s\t%s\t%s\t%s\n",
 				file.ParentDirectory,
 				file.Name(),
@@ -906,12 +906,12 @@ func (fi FileChecksumIndex) PrintFileMatches(blankLineBetweenSets bool) {
 		// This throws off cohesive formatting across all sets, but can be
 		// useful when focusing just on the sets themselves.
 		if blankLineBetweenSets {
-			fmt.Fprintln(w)
+			_, _ = fmt.Fprintln(w)
 		}
 
 	}
 
-	fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w)
 	if err := w.Flush(); err != nil {
 		log.Printf(
 			"error occurred flushing tabwriter: %v",
@@ -932,14 +932,14 @@ func (dfs DuplicateFilesSummary) PrintSummary() {
 	w.Init(os.Stdout, 8, 8, 5, '\t', 0)
 
 	// TODO: Use tabwriter to generate summary report?
-	fmt.Fprintf(w, "%d\tevaluated files in specified paths\n", dfs.TotalEvaluatedFiles)
-	fmt.Fprintf(w, "%d\tpotential duplicate file sets found using file size\n", dfs.FileSizeMatchSets)
-	fmt.Fprintf(w, "%d\tconfirmed duplicate file sets found using file hash\n", dfs.FileHashMatchSets)
-	fmt.Fprintf(w, "%d\tfiles with identical file size\n", dfs.FileSizeMatches)
-	fmt.Fprintf(w, "%d\tfiles with identical file hash\n", dfs.FileHashMatches)
-	fmt.Fprintf(w, "%d\tduplicate files\n", dfs.DuplicateCount)
-	fmt.Fprintf(w, "%s\twasted space for duplicate file sets\n", units.ByteCountIEC(dfs.WastedSpace))
-	fmt.Fprintln(w)
+	_, _ = fmt.Fprintf(w, "%d\tevaluated files in specified paths\n", dfs.TotalEvaluatedFiles)
+	_, _ = fmt.Fprintf(w, "%d\tpotential duplicate file sets found using file size\n", dfs.FileSizeMatchSets)
+	_, _ = fmt.Fprintf(w, "%d\tconfirmed duplicate file sets found using file hash\n", dfs.FileHashMatchSets)
+	_, _ = fmt.Fprintf(w, "%d\tfiles with identical file size\n", dfs.FileSizeMatches)
+	_, _ = fmt.Fprintf(w, "%d\tfiles with identical file hash\n", dfs.FileHashMatches)
+	_, _ = fmt.Fprintf(w, "%d\tduplicate files\n", dfs.DuplicateCount)
+	_, _ = fmt.Fprintf(w, "%s\twasted space for duplicate file sets\n", units.ByteCountIEC(dfs.WastedSpace))
+	_, _ = fmt.Fprintln(w)
 
 	if err := w.Flush(); err != nil {
 		log.Printf(


### PR DESCRIPTION
Resolve `return value of fmt.Fprintf is not checked`` errors by
explicitly discarding return values (potential error, bytes written)
since we do not need them and the potential for failure (in this
particular use case) is *highly* unlikely.
