### PR TITLE
Fix govet linting errors raised by updated linter

### DIFF
--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -10,6 +10,7 @@
 package paths
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -271,7 +272,7 @@ func BackupFile(sourceFilename string, destinationDirectory string) error {
 			sourceFileStat.Size(),
 		)
 		log.Println(sizeCopiedMismatchMsg)
-		return fmt.Errorf(sizeCopiedMismatchMsg)
+		return errors.New(sizeCopiedMismatchMsg)
 	}
 
 	// copy was successful, we should cleanup and log (DEBUG) how much data


### PR DESCRIPTION
Surfaced by golangci-lint v1.60.1 (built with Go 1.23.0).